### PR TITLE
Adds exit codes to update scripts

### DIFF
--- a/bering-strait/bering_strait_save/update.sh
+++ b/bering-strait/bering_strait_save/update.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+FAILS=0
+
 #check for ncdump
 command -v ncdump >/dev/null 2>&1 || { echo "ncdump is required but not installed (aptitude install -y netcdf-bin)" >&2; exit 1; }
 
@@ -10,6 +12,7 @@ if [ $? -eq 0 ]; then
     mv GFS_download.nc GFS.nc
 else
     echo "Problem downloading GFS files"
+    let "FAILS += 1"
 fi
 
 # Get HYCOM
@@ -19,4 +22,8 @@ if [ $? -eq 0 ]; then
     mv HYCOM_download.nc HYCOM.nc
 else
     echo "Problem downloading HYCOM files"
+    let "FAILS += 1"
 fi
+
+exit $FAILS
+

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ALL_EXIT=0
+
 for d in $(find -type f -name update.sh); do
     if [ "$d" = "$0" ];
     then
@@ -10,5 +12,9 @@ for d in $(find -type f -name update.sh); do
     cd $(dirname $d)
     echo "Running $(basename $d) from $(dirname $d)"
     bash $(basename $d)
+    let "ALL_EXIT=$ALL_EXIT || $?"
     popd
 done
+
+exit $ALL_EXIT
+


### PR DESCRIPTION
@kwilcox 

So we get this in `docker ps --all`:

```
CONTAINER ID        IMAGE                 COMMAND                  CREATED             STATUS                      PORTS               NAMES
794b8338621c        gnome-locations       "/bin/sh -c ./update."   10 minutes ago      Exited (1) 10 minutes ago                       loc
```

Caveats: 
- The bering-strait update script will exit with number of failures, but the bash `||` appears to be changing it to binary.  Could use `+=` for number of failures, but really all I care about is non-zero.
